### PR TITLE
Added formats and patterns, fixed org properties

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -15,8 +15,11 @@
           "type": "string"
         },
         "country": {
-          "description": "Country code [XX]",
-          "type": "string"
+          "description": "ISO 3166-1 alpha 2 country code [XX]",
+          "type": "string",
+          "maxLength": 2,
+          "minLength": 2,
+          "pattern": "^[A-Z]+$"
         },
         "latitude": {
           "description": "Latitude in decimal degrees",
@@ -43,22 +46,24 @@
       "description": "Producer account name",
       "type": "string",
       "maxLength": 12,
-      "minLength": 1
+      "minLength": 1,
+      "pattern": "^[\\.12345a-z]+$"
     },
     "producer_public_key": {
       "$id": "/properties/producer_public_key",
       "description": "Public key starting with EOS",
       "type": "string",
       "maxLength": 53,
-      "minLength": 53
+      "minLength": 53,
+      "pattern": "^EOS[\\w\\d]+$"
     },
     "org": {
       "type": "object",
-      "properties/location": {
+      "properties": {
         "location": {
           "$ref": "#/definitions/location",
           "description": "Organization location",
-          "type": "location"
+          "type": "object"
         },
         "candidate_name": {
           "$id": "/properties/org/properties/candidate_name",
@@ -68,22 +73,26 @@
         "website": {
           "$id": "/properties/org/properties/website",
           "description": "Organization website",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "code_of_conduct": {
           "$id": "/properties/org/properties/code_of_conduct",
           "description": "Link to Code of Conduct",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "ownership_disclosure": {
           "$id": "/properties/org/properties/ownership_disclosure",
           "description": "Link to company ownership disclosure",
-          "type": "string"
+          "type": "string",
+          "format": "uri"
         },
         "email": {
           "$id": "/properties/org/properties/email",
           "description": "Organization email",
-          "type": "string"
+          "type": "string",
+          "format": "email"
         },
         "branding": {
           "type": "object",
@@ -91,17 +100,20 @@
             "logo_256": {
               "$id": "/properties/org/properties/branding/properties/logo_256",
               "description": "Link to Organization logo [PNG format, 256x256]",
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "logo_1024": {
               "$id": "/properties/org/properties/branding/properties/logo_1024",
               "description": "Link to Organization logo [PNG format, 1024x1024]",
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             },
             "logo_svg": {
               "$id": "/properties/org/properties/branding/properties/logo_svg",
               "description": "Link to Organization logo [SVG format]",
-              "type": "string"
+              "type": "string",
+              "format": "uri"
             }
           }
         },
@@ -110,39 +122,48 @@
           "properties": {
             "facebook": {
               "description": "group/page address only, not the entire url",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "github": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "keybase": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "reddit": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "steemit": {
               "description": "username only, WITHOUT @",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "telegram": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "twitter": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "wechat": {
               "description": "username only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             },
             "youtube": {
               "description": "channel address only",
-              "type": "String"
+              "type": "string",
+              "pattern": "^[\\w\\d_\\-\\.]+$"
             }
           }
         }
@@ -169,11 +190,20 @@
           },
           "node_type": {
             "description": "Type of service",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": ["producer", "full", "query", "seed"]
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "enum": ["producer", "full", "query", "seed"]
+                }
+              },
+              {
+                "type": "string",
+                "enum": ["producer", "full", "query", "seed"]
+              }
+            ]
           },
           "p2p_endpoint": {
             "description": "EOSIO P2P endpoint (host:port)",
@@ -185,11 +215,13 @@
           },
           "api_endpoint": {
             "description": "EOSIO HTTP endpoint (http://host:port)",
-            "type": "string"
+            "type": "string",
+            "pattern": "^http://.+$"
           },
           "ssl_endpoint": {
             "description": "EOSIO HTTPS endpoint (https://host:port)",
-            "type": "string"
+            "type": "string",
+            "pattern": "^https://.+$"
           }
         }
       }

--- a/schema.json
+++ b/schema.json
@@ -74,19 +74,22 @@
           "$id": "/properties/org/properties/website",
           "description": "Organization website",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "pattern": "^https?://"
         },
         "code_of_conduct": {
           "$id": "/properties/org/properties/code_of_conduct",
           "description": "Link to Code of Conduct",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "pattern": "^https?://"
         },
         "ownership_disclosure": {
           "$id": "/properties/org/properties/ownership_disclosure",
           "description": "Link to company ownership disclosure",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "pattern": "^https?://"
         },
         "email": {
           "$id": "/properties/org/properties/email",
@@ -101,19 +104,22 @@
               "$id": "/properties/org/properties/branding/properties/logo_256",
               "description": "Link to Organization logo [PNG format, 256x256]",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "pattern": "^https?://"
             },
             "logo_1024": {
               "$id": "/properties/org/properties/branding/properties/logo_1024",
               "description": "Link to Organization logo [PNG format, 1024x1024]",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "pattern": "^https?://"
             },
             "logo_svg": {
               "$id": "/properties/org/properties/branding/properties/logo_svg",
               "description": "Link to Organization logo [SVG format]",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "pattern": "^https?://"
             }
           }
         },
@@ -216,12 +222,14 @@
           "api_endpoint": {
             "description": "EOSIO HTTP endpoint (http://host:port)",
             "type": "string",
-            "pattern": "^http://.+$"
+            "format": "uri",
+            "pattern": "^http://"
           },
           "ssl_endpoint": {
             "description": "EOSIO HTTPS endpoint (https://host:port)",
             "type": "string",
-            "pattern": "^https://.+$"
+            "format": "uri",
+            "pattern": "^https://"
           }
         }
       }

--- a/schema.json
+++ b/schema.json
@@ -30,6 +30,25 @@
           "type": "number"
         }
       }
+    },
+    "required_url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https?://"
+    },
+    "optional_url": {
+      "type": "string",
+      "if": {
+        "pattern": ".+"
+      },
+      "then": {
+        "format": "uri",
+        "pattern": "^https?://"
+      }
+    },
+    "username": {
+      "type": "string",
+      "pattern": "^[\\w\\d_\\-\\.]*$"
     }
   },
   "type": "object",
@@ -62,8 +81,7 @@
       "properties": {
         "location": {
           "$ref": "#/definitions/location",
-          "description": "Organization location",
-          "type": "object"
+          "description": "Organization location"
         },
         "candidate_name": {
           "$id": "/properties/org/properties/candidate_name",
@@ -71,25 +89,16 @@
           "type": "string"
         },
         "website": {
-          "$id": "/properties/org/properties/website",
-          "description": "Organization website",
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https?://"
+          "$ref": "#/definitions/required_url",
+          "description": "Organization website"
         },
         "code_of_conduct": {
-          "$id": "/properties/org/properties/code_of_conduct",
-          "description": "Link to Code of Conduct",
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https?://"
+          "$ref": "#/definitions/optional_url",
+          "description": "Link to Code of Conduct"
         },
         "ownership_disclosure": {
-          "$id": "/properties/org/properties/ownership_disclosure",
-          "description": "Link to company ownership disclosure",
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https?://"
+          "$ref": "#/definitions/optional_url",
+          "description": "Link to company ownership disclosure"
         },
         "email": {
           "$id": "/properties/org/properties/email",
@@ -101,25 +110,16 @@
           "type": "object",
           "properties":{
             "logo_256": {
-              "$id": "/properties/org/properties/branding/properties/logo_256",
-              "description": "Link to Organization logo [PNG format, 256x256]",
-              "type": "string",
-              "format": "uri",
-              "pattern": "^https?://"
+              "$ref": "#/definitions/optional_url",
+              "description": "Link to Organization logo [PNG format, 256x256]"
             },
             "logo_1024": {
-              "$id": "/properties/org/properties/branding/properties/logo_1024",
-              "description": "Link to Organization logo [PNG format, 1024x1024]",
-              "type": "string",
-              "format": "uri",
-              "pattern": "^https?://"
+              "$ref": "#/definitions/optional_url",
+              "description": "Link to Organization logo [PNG format, 1024x1024]"
             },
             "logo_svg": {
-              "$id": "/properties/org/properties/branding/properties/logo_svg",
-              "description": "Link to Organization logo [SVG format]",
-              "type": "string",
-              "format": "uri",
-              "pattern": "^https?://"
+              "$ref": "#/definitions/optional_url",
+              "description": "Link to Organization logo [SVG format]"
             }
           }
         },
@@ -127,49 +127,40 @@
           "type": "object",
           "properties": {
             "facebook": {
-              "description": "group/page address only, not the entire url",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "group/page address only, not the entire url"
             },
             "github": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "keybase": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "reddit": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "steemit": {
-              "description": "username only, WITHOUT @",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only, WITHOUT @"
             },
             "telegram": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "twitter": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "wechat": {
-              "description": "username only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "username only"
             },
             "youtube": {
-              "description": "channel address only",
-              "type": "string",
-              "pattern": "^[\\w\\d_\\-\\.]+$"
+              "$ref": "#/definitions/username",
+              "description": "channel address only"
             }
           }
         }
@@ -222,14 +213,24 @@
           "api_endpoint": {
             "description": "EOSIO HTTP endpoint (http://host:port)",
             "type": "string",
-            "format": "uri",
-            "pattern": "^http://"
+            "if": {
+              "pattern": ".+"
+            },
+            "then": {
+              "format": "uri",
+              "pattern": "^http://"
+            }
           },
           "ssl_endpoint": {
             "description": "EOSIO HTTPS endpoint (https://host:port)",
             "type": "string",
-            "format": "uri",
-            "pattern": "^https://"
+            "if": {
+              "pattern": ".+"
+            },
+            "then": {
+              "format": "uri",
+              "pattern": "^https://"
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds a few things:

- `pattern` attributes for things like country codes, EOS account names/public keys, site usernames, and node URLs.
- `format` attributes for website/image URLs and emails.
- Allows `node_type` to be either an array or a string to preserve backwards compatibility.
- Fixes the `org` properties so they actually validate. It was set to `properties/location` before and it wasn't actually validating any `org` properties. Not sure how it passed the JSON schema validator.