### PR TITLE
Ensure org -> website has no trailing slash

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -31,10 +31,10 @@
         }
       }
     },
-    "required_url": {
+    "required_website_url": {
       "type": "string",
       "format": "uri",
-      "pattern": "^https?://"
+      "pattern": "^https?://.+[^\/]$"
     },
     "optional_url": {
       "type": "string",
@@ -80,7 +80,7 @@
           "type": "string"
         },
         "website": {
-          "$ref": "#/definitions/required_url",
+          "$ref": "#/definitions/required_website_url",
           "description": "Organization website"
         },
         "code_of_conduct": {


### PR DESCRIPTION
For org -> website, many tools such as [https://tools.eosmetal.io/nodestatus/eos](https://tools.eosmetal.io/nodestatus/eos) concatenate `org.website+"/<resource>"` to generate a link to a static asset (ex. org.website+"/bp.json").

I have also renamed `required_url` to `required_website_url`, as this proposed requires a new type which only covers a subset of URL.