### PR TITLE
Switch steemit to Hive (former is obsolete now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The current revision is compliant with the JSON schema Draft v7 - http://json-sc
       - longitude: Longitude in decimal degrees
     },
   - social: {Object} - NOT THE ENTIRE URL, only usernames on social networks, 
-    - steemit: Username without @
+    - hive: Username without @
     - twitter: Username
     - youtube: Channel address
     - facebook: Page/group address

--- a/bp.json
+++ b/bp.json
@@ -18,7 +18,7 @@
       "longitude": 0
     },
     "social": {
-      "steemit": "",
+      "hive": "",
       "twitter": "",
       "youtube": "",
       "facebook": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp-info-standard",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "**JSON Standard for Block Producer Information on the EOS Blockchain**",
   "main": "index.js",
   "repository": {

--- a/schema.json
+++ b/schema.json
@@ -133,7 +133,7 @@
               "$ref": "#/definitions/username",
               "description": "username only"
             },
-            "steemit": {
+            "hive": {
               "$ref": "#/definitions/username",
               "description": "username only, WITHOUT @"
             },


### PR DESCRIPTION
After a hostile takeover, Steem is now owned and controlled by thieves and frauds.
We've moved to Hive with all our Ideas, Values, and Efforts.
We've forked from Steem on 20 March 2020 to continue the legacy of decentralized, blockchain based social media platform on Hive.

Source: https://steem.blog

It's backwards compatible so old accounts (pre-fork date) are there
For example: https://hive.blog/@eosrio