### PR TITLE
Add support for snapshot endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The current revision is compliant with the JSON schema Draft v7 - http://json-sc
     - bnet_endpoint: EOSIO BNET endpoint `host:port`
     - api_endpoint: EOSIO HTTP endpoint `http://host:port`
     - ssl_endpoint: EOSIO HTTPS endpoint `https://host:port`
+    - snapshot_endpoint: BP endpoint for public snapshots `https://host:port`
 
 ### How to use it if you are Block Producer Candidate 
 Create a file named `bp.json` in the root of your domain. For instance `http://yourwebsite.com/bp.json` When you register your producer using the `system.regproducer` action, the url field should be filled with `http://yourwebsite.com`. **Do not put the bp.json file in the url.**

--- a/bp.json
+++ b/bp.json
@@ -41,7 +41,8 @@
       "p2p_endpoint": "",
       "bnet_endpoint": "",
       "api_endpoint": "",
-      "ssl_endpoint": ""
+      "ssl_endpoint": "",
+      "snapshot_endpoint": ""
     },
     {
       "location": {
@@ -54,7 +55,8 @@
       "p2p_endpoint": "",
       "bnet_endpoint": "",
       "api_endpoint": "",
-      "ssl_endpoint": ""
+      "ssl_endpoint": "",
+      "snapshot_endpoint": ""
     }
   ]
 }

--- a/schema.json
+++ b/schema.json
@@ -222,6 +222,17 @@
               "format": "uri",
               "pattern": "^https://"
             }
+          },
+          "snapshot_endpoint": {
+            "description": "BP endpoint for public snapshots (https://host:port)",
+            "type": "string",
+            "if": {
+              "pattern": ".+"
+            },
+            "then": {
+              "format": "uri",
+              "pattern": "^https?://"
+            }
           }
         }
       }


### PR DESCRIPTION
This adds support for a new `snapshot_endpoint` field for better discoverability of BP endpoints that offer public snapshot downloads.